### PR TITLE
Improve instructions for loading unpacked extensions

### DIFF
--- a/chrome/ScreenSharing/README.md
+++ b/chrome/ScreenSharing/README.md
@@ -28,7 +28,7 @@ See the following sections for testing and deploying your extension.
 
 ## Testing your unpacked extension
 
-Follow the instructions in the [Chrome extension documentation on loading and unpacked
+Open chrome://extensions and drag the ScreenSharing directory onto the page, or click 'Load unpacked extension...'. For more information see [Chrome's documentation on loading unpacked
 extensions][load-unpacked].
 
 [load-unpacked]: https://developer.chrome.com/extensions/getstarted#unpacked


### PR DESCRIPTION
It's so easy. It doesn't make sense to send the user to a completely different page. Makes it seem like a complicated thing.